### PR TITLE
# Adicionar GetAllWithEnderecoAsync ao repositório de Aluno

### DIFF
--- a/EscolaAPI.Application/Interfaces/IAlunoRepository.cs
+++ b/EscolaAPI.Application/Interfaces/IAlunoRepository.cs
@@ -11,5 +11,6 @@ namespace EscolaAPI.Application.Interfaces
     {
         Task<Aluno> GetAlunoWithEnderecoAsync(int id);
         Task<Aluno> GetAlunoByMatriculaAsync(string matricula);
+        Task<IEnumerable<Aluno>> GetAllWithEnderecoAsync();
     }
 }

--- a/EscolaAPI.Application/Queries/Alunos/GetAllAlunosQuery.cs
+++ b/EscolaAPI.Application/Queries/Alunos/GetAllAlunosQuery.cs
@@ -27,7 +27,7 @@ namespace EscolaAPI.Application.Queries.Alunos
 
         public async Task<IEnumerable<AlunoDto>> Handle(GetAllAlunosQuery request, CancellationToken cancellationToken) 
         {
-            var alunos = await _alunoRepository.GetAllAsync();
+            var alunos = await _alunoRepository.GetAllWithEnderecoAsync();
             return _mapper.Map<IEnumerable<AlunoDto>>(alunos);
         }
     }

--- a/EscolaAPI.Infrastructure/Repositories/AlunoRepository.cs
+++ b/EscolaAPI.Infrastructure/Repositories/AlunoRepository.cs
@@ -27,5 +27,12 @@ namespace EscolaAPI.Infrastructure.Repositories
                 .Include(a => a.Endereco)
                 .FirstOrDefaultAsync(a => a.Matricula == matricula);
         }
+
+        public async Task<IEnumerable<Aluno>> GetAllWithEnderecoAsync()
+        {
+            return await _context.Alunos
+                .Include(a => a.Endereco)
+                .ToListAsync();
+        }
     }
 }


### PR DESCRIPTION
Atualizado IAlunoRepository para incluir o método GetAllWithEnderecoAsync para recuperar objetos Aluno com seus dados de Endereco associados. Modificado GetAllAlunosQuery para usar o novo método, garantindo que todos os registros de Aluno recuperados incluam informações relacionadas de Endereco. Implementado o novo método em AlunoRepository para buscar dados usando o método Include do Entity Framework.